### PR TITLE
fix(vnc): password auth, path detection, dynamic domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.1.0-beta.1 (2026-02-10)
+
+### Fixed
+- **VNC password authentication**: Replace `-nopw` with `-rfbauth` using auto-generated password file
+- **websockify path detection**: Auto-detect noVNC web directory across common installation paths
+- **Dynamic VNC URL**: Read domain from `~/zylos/.env` instead of hardcoded `zylos10.jinglever.com`
+
+### Added
+- `http_routes` in SKILL.md for automatic Caddy `/vnc/*` reverse proxy configuration
+- `loadEnv()` helper in config.js for reading `~/zylos/.env`
+- VNC password auto-generation in post-install hook
+- Auto-start display infrastructure when all dependencies are present
+
+---
+
 ## 0.1.0 (2026-02-10)
 
 Initial release.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser
-version: 0.1.0
+version: 0.1.0-beta.1
 description: General-purpose browser automation capability
 type: capability
 
@@ -27,6 +27,12 @@ config:
 
 bin:
   zylos-browser: src/cli.js
+
+http_routes:
+  - path: /vnc/*
+    type: reverse_proxy
+    target: localhost:6080
+    strip_prefix: /vnc
 
 dependencies: []
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-browser",
-  "version": "0.1.0",
+  "version": "0.1.0-beta.1",
   "description": "General-purpose browser automation capability for Zylos agents",
   "type": "module",
   "scripts": {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -50,6 +50,38 @@ export const DEFAULT_CONFIG = {
 };
 
 let config = null;
+let envCache = null;
+
+/**
+ * Load environment variables from ~/zylos/.env
+ * Returns an object with parsed key=value pairs.
+ */
+export function loadEnv() {
+  if (envCache) return envCache;
+  envCache = {};
+  try {
+    if (fs.existsSync(ENV_FILE)) {
+      const content = fs.readFileSync(ENV_FILE, 'utf8');
+      for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eqIdx = trimmed.indexOf('=');
+        if (eqIdx === -1) continue;
+        const key = trimmed.slice(0, eqIdx).trim();
+        let value = trimmed.slice(eqIdx + 1).trim();
+        // Strip surrounding quotes
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        envCache[key] = value;
+      }
+    }
+  } catch {
+    // .env not found or not readable — ok
+  }
+  return envCache;
+}
 
 /**
  * Deep merge two objects. Source values override target.


### PR DESCRIPTION
## Summary
- Fix VNC security: replace `-nopw` with password authentication (`-rfbauth`)
- Fix websockify path detection: auto-detect noVNC directory across common paths
- Fix hardcoded domain: read from `~/zylos/.env` instead of `zylos10.jinglever.com`
- Add `http_routes` in SKILL.md for automatic Caddy `/vnc/*` reverse proxy configuration

## Changes
| File | Change |
|------|--------|
| `SKILL.md` | Add `http_routes` field for Caddy auto-config, bump to v0.1.1 |
| `src/lib/display.js` | VNC password auth, noVNC path detection, dynamic domain URL |
| `src/lib/config.js` | Add `loadEnv()` helper for reading `~/zylos/.env` |
| `hooks/post-install.js` | VNC password generation, auto-start display when deps present |
| `CHANGELOG.md` | Document v0.1.1 |
| `package.json` | Bump to v0.1.1 |

## Issues addressed
1. **VNC insecure** — `-nopw` flag replaced with `-rfbauth` using auto-generated password
2. **websockify not running** — path detection now checks multiple common directories
3. **noVNC inaccessible** — `http_routes` enables Caddy auto-config (requires zylos-core PR)

## Test plan
- [ ] All 36 existing tests pass
- [ ] `getVNCUrl()` returns domain from .env
- [ ] Post-install generates `.vncpasswd` file
- [ ] `display start` uses `-rfbauth` flag
- [ ] End-to-end on zylos0: VNC accessible with password via `/vnc/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)