### PR TITLE
fix(skill): add PATH setup note for bin commands

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -43,6 +43,7 @@ General-purpose browser automation capability for Zylos agents.
 
 ## Important
 
+- **PATH setup**: Before first use in a session, run: `export PATH="$HOME/zylos/bin:$PATH"`
 - **noVNC URL**: Always use `zylos-browser display vnc-url` to get the correct noVNC URL. Do NOT construct the URL manually — it includes required WebSocket path parameters.
 - **Display must be started** before any browser commands: `zylos-browser display start`
 


### PR DESCRIPTION
## Summary

- Add PATH setup instruction to SKILL.md Important section
- Claude reads this when loading the browser skill and sets PATH before using `zylos-browser` commands

## Context

On fresh install, `~/zylos/bin` may not be in the current session's PATH. This one-line note tells Claude to `export PATH="$HOME/zylos/bin:$PATH"` before first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)