### PR TITLE
fix(deps): make all browser dependencies auto-installed and managed

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,7 @@ config:
 
 bin:
   zylos-browser: src/cli.js
+  agent-browser: node_modules/.bin/agent-browser
 
 http_routes:
   - path: /vnc/*
@@ -48,10 +49,9 @@ General-purpose browser automation capability for Zylos agents.
 
 ## Dependencies
 
-- agent-browser CLI (globally installed)
-- Chrome/Chromium with CDP enabled
-- Xvfb (for headless display)
-- x11vnc + websockify (for VNC/noVNC access, auto-installed by post-install)
+- agent-browser CLI (installed as npm dependency, linked to ~/zylos/bin/)
+- Chrome/Chromium with CDP enabled (auto-installed by post-install)
+- Xvfb, x11vnc, websockify (auto-installed by post-install)
 
 ## When to Use
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "agent-browser": "^0.9.2",
     "playwright-core": "^1.57.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -290,22 +290,28 @@ async function displayCmd(cmdArgs) {
     case 'status': {
       const status = await display.getDisplayStatus();
       console.log('Display status:');
-      console.log(`  Xvfb:  ${status.xvfb ? 'running' : 'stopped'}`);
-      console.log(`  VNC:   ${status.vnc ? 'running' : 'stopped'}`);
-      console.log(`  noVNC: ${status.novnc ? 'running' : 'stopped'}`);
+      console.log(`  Xvfb:   ${status.xvfb ? 'running' : 'stopped'}`);
+      console.log(`  Chrome: ${status.chrome ? 'running' : 'stopped'}`);
+      console.log(`  VNC:    ${status.vnc ? 'running' : 'stopped'}`);
+      console.log(`  noVNC:  ${status.novnc ? 'running' : 'stopped'}`);
       console.log(`  DISPLAY: ${status.display}`);
       break;
     }
     case 'start': {
-      const result = await display.ensureDisplay();
-      console.log(`Display ready (DISPLAY=${result.display})`);
-      if (result.started) console.log('  Xvfb was started.');
+      const xvfb = await display.ensureDisplay();
+      console.log(`Display ready (DISPLAY=${xvfb.display})`);
+      if (xvfb.started) console.log('  Xvfb was started.');
+      const chrome = await display.ensureChrome();
+      console.log(`Chrome ready (CDP port ${chrome.cdpPort})`);
+      if (chrome.started) console.log('  Chrome was started.');
       const vnc = await display.startVNC();
       console.log(`VNC started on port ${vnc.vncPort}`);
       if (vnc.url) console.log(`noVNC: ${vnc.url}`);
       break;
     }
     case 'stop': {
+      await display.stopChrome();
+      console.log('Chrome stopped.');
       await display.stopVNC();
       console.log('VNC stopped.');
       break;

--- a/src/lib/display.js
+++ b/src/lib/display.js
@@ -15,6 +15,14 @@ import { getConfig, DATA_DIR, ZYLOS_DIR } from './config.js';
 
 const execFile = promisify(execFileCb);
 
+/** Chrome binary candidates in preference order */
+const CHROME_CANDIDATES = [
+  'google-chrome-stable',
+  'google-chrome',
+  'chromium-browser',
+  'chromium',
+];
+
 /**
  * Check if a PM2 process is running by name
  */
@@ -79,16 +87,99 @@ export async function ensureDisplay(options = {}) {
 }
 
 /**
+ * Find the Chrome/Chromium binary on this system.
+ * @returns {string|null} Path to Chrome binary, or null if not found
+ */
+export function findChromeBinary() {
+  for (const bin of CHROME_CANDIDATES) {
+    try {
+      const result = execSync(`which ${bin}`, { encoding: 'utf-8', stdio: 'pipe' }).trim();
+      if (result) return result;
+    } catch {
+      // not found, try next
+    }
+  }
+  return null;
+}
+
+/**
+ * Ensure Chrome is running with CDP enabled via PM2.
+ *
+ * @param {object} options - Override settings
+ * @returns {{ cdpPort: number, started: boolean }}
+ */
+export async function ensureChrome(options = {}) {
+  const config = getConfig();
+  const cdpPort = options.cdpPort ?? config.cdp_port ?? 9222;
+  const displayNum = options.displayNumber ?? config.display?.number ?? 99;
+
+  const isRunning = await isPM2Running('zylos-chrome');
+  if (isRunning) {
+    return { cdpPort, started: false };
+  }
+
+  const chromeBin = findChromeBinary();
+  if (!chromeBin) {
+    throw new Error('Chrome/Chromium not found. Install with: sudo apt-get install -y chromium-browser');
+  }
+
+  const chromeArgs = [
+    `--remote-debugging-port=${cdpPort}`,
+    '--user-data-dir=/tmp/chrome-zylos',
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-background-networking',
+    '--disable-sync',
+    '--disable-translate',
+    '--disable-extensions',
+    '--disable-default-apps',
+    '--disable-features=TranslateUI',
+    '--window-size=1920,1080',
+    '--window-position=0,0',
+    'about:blank',
+  ].join(' ');
+
+  // Use bash -c to launch Chrome so PM2 doesn't try to interpret it as Node.js
+  const script = `DISPLAY=:${displayNum} ${chromeBin} ${chromeArgs}`;
+
+  try {
+    await execFile('pm2', [
+      'start', 'bash',
+      '--name', 'zylos-chrome',
+      '--', '-c', script
+    ], { timeout: 15000 });
+
+    // Wait for Chrome to be ready
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    return { cdpPort, started: true };
+  } catch (err) {
+    throw new Error(`Failed to start Chrome: ${err.message}`);
+  }
+}
+
+/**
+ * Stop Chrome PM2 process
+ */
+export async function stopChrome() {
+  try {
+    await execFile('pm2', ['delete', 'zylos-chrome'], { timeout: 10000 });
+  } catch {
+    // Already stopped or doesn't exist
+  }
+}
+
+/**
  * Get status of display infrastructure
  *
- * @returns {{ xvfb: boolean, vnc: boolean, novnc: boolean, display: string }}
+ * @returns {{ xvfb: boolean, chrome: boolean, vnc: boolean, novnc: boolean, display: string }}
  */
 export async function getDisplayStatus() {
   const config = getConfig();
   const display = `:${config.display?.number ?? 99}`;
 
-  const [xvfb, vnc] = await Promise.all([
+  const [xvfb, chrome, vnc] = await Promise.all([
     isPM2Running('zylos-xvfb'),
+    isPM2Running('zylos-chrome'),
     isPM2Running('zylos-vnc')
   ]);
 
@@ -104,7 +195,7 @@ export async function getDisplayStatus() {
     }
   }
 
-  return { xvfb, vnc, novnc, display };
+  return { xvfb, chrome, vnc, novnc, display };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Move agent-browser from global `npm install -g` to local dependency (package.json + SKILL.md bin)
- Add Chrome auto-install in post-install hook (apt chromium-browser, fallback Google Chrome .deb)
- All system deps (Xvfb, x11vnc, websockify) now required — exit on failure
- Chrome lifecycle management in display.js (start/stop/status via PM2 with bash interpreter)
- Fixes zylos-chrome PM2 SyntaxError on zylos0 (was running shell wrapper with Node.js interpreter)

## Test plan
- [ ] Fresh `zylos add browser` on clean server — all deps auto-install
- [ ] `zylos-browser display start` starts Xvfb → Chrome → VNC
- [ ] `zylos-browser display status` shows all 4 services
- [ ] `zylos-browser display stop` stops Chrome + VNC
- [ ] agent-browser available at ~/zylos/bin/agent-browser after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)