### PR TITLE
docs: add release process guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,19 @@ Development guidelines for zylos-browser.
 - **Secrets in `.env` only** — Never commit secrets. Use `~/zylos/.env` for credentials, `config.json` for non-sensitive runtime config
 - **English for code** — Comments, commit messages, PR descriptions, and documentation in English
 
+## Release Process
+
+When releasing a new version, **all four files** must be updated in the same commit:
+
+1. **`package.json`** — Bump `version` field
+2. **`package-lock.json`** — Run `npm install` after bumping package.json to sync the lock file
+3. **`SKILL.md`** — Update `version` in YAML frontmatter to match package.json
+4. **`CHANGELOG.md`** — Add new version entry following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
+
+Version bump commit message: `chore: bump version to X.Y.Z`
+
+After merge, create a GitHub Release with tag `vX.Y.Z` from the merge commit.
+
 ## Architecture
 
 This is a **capability component** for the Zylos agent ecosystem.


### PR DESCRIPTION
Add release process section documenting which files must be updated during version bumps (package.json, package-lock.json, CHANGELOG.md, and SKILL.md if applicable).