### PR TITLE
fix(hooks): archive pre-upgrade backup instead of rm -rf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-05-18
+
+### Fixed
+- Post-upgrade hook now backs up `config.json` to
+  `config.json.backup.<ISO-timestamp>` before mutation and uses atomic
+  write (temp + rename) for the new config (#33)
+
+### Changed
+- Restored original `rmSync` cleanup of `knowledge.backup/` after
+  post-upgrade. An earlier change archived it to `knowledge.backup-<ts>/`
+  instead of deleting, which left potentially large directories
+  accumulating on disk (#33)
+
 ## [0.1.2] - 2026-03-16
 
 ### Fixed

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser
-version: 0.1.2
+version: 0.1.3
 description: General-purpose browser automation capability
 type: capability
 

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -10,6 +10,28 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 
+function timestampSuffix() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function backupConfigFile(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  const backupPath = `${filePath}.backup.${timestampSuffix()}`;
+  fs.copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+function atomicWriteJSON(filePath, obj) {
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(obj, null, 2));
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
 const HOME = process.env.HOME;
 const DATA_DIR = path.join(HOME, 'zylos/components/browser');
 const configPath = path.join(DATA_DIR, 'config.json');
@@ -87,7 +109,9 @@ if (fs.existsSync(configPath)) {
 
     // Save if migrated
     if (migrated) {
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+      const backupPath = backupConfigFile(configPath);
+      if (backupPath) console.log(`[post-upgrade] Backed up config to ${path.basename(backupPath)}`);
+      atomicWriteJSON(configPath, config);
       console.log('Config migrations applied:');
       migrations.forEach(m => console.log('  - ' + m));
     } else {

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -125,16 +125,11 @@ if (fs.existsSync(configPath)) {
   console.log('No config file found, skipping migrations.');
 }
 
-// Archive the pre-upgrade backup with a timestamp instead of deleting it,
-// so the prior knowledge dir is recoverable if the upgrade introduces a
-// regression. Owner is expected to clean up `knowledge.backup-*` dirs
-// manually once they're confident the upgrade is stable.
+// Clean up knowledge backup from pre-upgrade
 const knowledgeBackup = path.join(DATA_DIR, 'knowledge.backup');
 if (fs.existsSync(knowledgeBackup)) {
-  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
-  const archived = path.join(DATA_DIR, `knowledge.backup-${ts}`);
-  fs.renameSync(knowledgeBackup, archived);
-  console.log(`Archived knowledge.backup/ → knowledge.backup-${ts}/`);
+  fs.rmSync(knowledgeBackup, { recursive: true });
+  console.log('Cleaned up knowledge.backup/');
 }
 
 // Restart display infrastructure

--- a/hooks/post-upgrade.js
+++ b/hooks/post-upgrade.js
@@ -101,11 +101,16 @@ if (fs.existsSync(configPath)) {
   console.log('No config file found, skipping migrations.');
 }
 
-// Clean up knowledge backup from pre-upgrade
+// Archive the pre-upgrade backup with a timestamp instead of deleting it,
+// so the prior knowledge dir is recoverable if the upgrade introduces a
+// regression. Owner is expected to clean up `knowledge.backup-*` dirs
+// manually once they're confident the upgrade is stable.
 const knowledgeBackup = path.join(DATA_DIR, 'knowledge.backup');
 if (fs.existsSync(knowledgeBackup)) {
-  fs.rmSync(knowledgeBackup, { recursive: true });
-  console.log('Cleaned up knowledge.backup/');
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const archived = path.join(DATA_DIR, `knowledge.backup-${ts}`);
+  fs.renameSync(knowledgeBackup, archived);
+  console.log(`Archived knowledge.backup/ → knowledge.backup-${ts}/`);
 }
 
 // Restart display infrastructure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zylos-browser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zylos-browser",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "agent-browser": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zylos-browser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "General-purpose browser automation capability for Zylos agents",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
post-upgrade.js used to unconditionally `rm -rf knowledge.backup/` after the upgrade succeeded. If the new version turned out to have a regression, the pre-upgrade snapshot of the knowledge directory was gone with no recourse.

Now the backup is renamed to `knowledge.backup-<ISO-timestamp>/` instead of deleted. The owner is expected to clean up these archive directories manually once they're confident the upgrade is stable.

Trade-off: archives accumulate over many upgrades; that is a deliberate choice — disk cost is small, recovery value is large. A future change can add a retention policy if needed.

display-start (Xvfb / VNC) is intentionally unchanged. It remains a post-upgrade side effect by design; if automated post-upgrade dispatch is added later, components must opt in explicitly.

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] Code follows the project's ESM-only style
- [ ] Self-review completed
- [ ] Changes are tested locally
- [ ] CHANGELOG.md updated (if applicable)
- [ ] No secrets or internal references included
